### PR TITLE
Add missing dependency for @react-navigation/native

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@react-navigation/bottom-tabs": "^6.5.7",
+    "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
     "expo": "^44.0.0",
     "expo-screen-orientation": "~4.1.1",


### PR DESCRIPTION
Was facing a error when doing npm start due to the miss of this