### PR TITLE
Fix display description in Recently Uploaded

### DIFF
--- a/screens/Describe/Index.tsx
+++ b/screens/Describe/Index.tsx
@@ -122,7 +122,7 @@ export default function Describe({ navigation }: IScreenProps) {
               placeholder="E.g. John Smith Form"
               fontSize="lg"
               py={3}
-              onBlur={(e) => setDescription(e.nativeEvent.text)}
+              onChange={(e) => setDescription(e.nativeEvent.text)}
             />
           </Stack>
         </FormControl>


### PR DESCRIPTION
The file description wasn't showing in Recently Uploaded list anymore, not sure why onBlur wasn't working here.

<img width="352" alt="Screen Shot 2023-05-18 at 11 21 17 AM" src="https://github.com/benefitter/bat_signal/assets/3835098/501e01a7-ff7d-410b-9f1c-c4c3e29bb6b7">
