### PR TITLE
Fixed closing button in Camera page

### DIFF
--- a/screens/Camera/Index.tsx
+++ b/screens/Camera/Index.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, VStack, View, useColorModeValue } from 'native-base';
+import { Button, Flex, VStack, useColorModeValue } from 'native-base';
 import React, { useCallback } from 'react';
 import CameraComp from '../../components/Camera/CameraComp';
 import LayoutPage from '../../components/layout/Page/Index';
@@ -16,9 +16,9 @@ export default function Describe({ navigation }: IScreenProps) {
 
   return (
     <LayoutPage bgColor={'#a2a1a8'}>
-      <View mt={4} style={{ flexDirection: 'row', justifyContent: 'flex-end' }}>
+      <Flex align="flex-end" mt={4} zIndex={10}>
         <CloseButton />
-      </View>
+      </Flex>
       <Flex align="center" height="96%">
         <VStack flexGrow={1} space={4} width="100%" justifyContent="center">
           <CameraComp />
@@ -30,6 +30,7 @@ export default function Describe({ navigation }: IScreenProps) {
           w="100%"
           roundedBottom="none"
           borderRadius={10}
+          mb="5"
         >
           <SnapshotIcon size={20} />
         </Button>


### PR DESCRIPTION
Also added a bit of margin bottom so the rounded button at the bottom isn't cutoff in some screens

<img width="364" alt="Screen Shot 2023-05-18 at 12 01 11 PM" src="https://github.com/benefitter/bat_signal/assets/3835098/ae372cf0-cee3-4ee9-b52c-7184aa116023">
